### PR TITLE
Add missing getmount import for split keyboards

### DIFF
--- a/src/main/pythontemplates/kb.ts
+++ b/src/main/pythontemplates/kb.ts
@@ -38,6 +38,7 @@ class KMKKeyboard(_KMKKeyboard):
 
         if pog.config['split']:
             from kmk.modules.split import Split, SplitSide, SplitType
+            from storage import getmount
             side = SplitSide.RIGHT if str(getmount('/').label)[-1] == 'R' else SplitSide.LEFT
             if pog.splitPinB:
               print("split with 2 pins")


### PR DESCRIPTION
Noticed error from RPi pico serial feed:

```
>>> Traceback (most recent call last):
  File "code.py", line 17, in <module>
  File "kb.py", line 43, in __init__
NameError: name 'getmount' is not defined
```

Adding import seems to fix it :)