### PR TITLE
Fix issue with directPins scanner initialization

### DIFF
--- a/src/main/pythontemplates/coordmaphelper.ts
+++ b/src/main/pythontemplates/coordmaphelper.ts
@@ -5,6 +5,7 @@ from kb import KMKKeyboard as _KMKKeyboard
 import pog
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
         print("running coord_mapping assistant")
         print("press each key to get its coord_mapping value")
     # *2 for split keyboards, which will typically manage twice the number of keys

--- a/src/main/pythontemplates/kb.ts
+++ b/src/main/pythontemplates/kb.ts
@@ -71,17 +71,23 @@ class KMKKeyboard(_KMKKeyboard):
                 val_default=20,
             )
             self.extensions.append(rgb)
-
-
+        
+        # direct pin wiring
+        # Must be set during init to override defaulting to matrix wiring
+        if pog.directWiring:
+            self.matrix = KeysScanner(
+                pins=eval(pog.pins),
+                value_when_pressed=False,
+                pull=True,
+                interval=0.02,
+                max_events=64
+            )
+          
     # matrix wiring
     if pog.matrixWiring:
         exec("col_pins = (" + pog.colPins + ")")
         exec("row_pins = (" + pog.rowPins + ")")
         exec("diode_orientation = DiodeOrientation." + pog.config["diodeDirection"])
-
-    # direct pin wiring
-    if pog.directWiring:
-        exec(pog.directPinScanner)
 
     # coord_mapping
     if len(pog.config["coordMap"]) != 0:

--- a/src/main/pythontemplates/pog.ts
+++ b/src/main/pythontemplates/pog.ts
@@ -92,23 +92,6 @@ def convert_coord_mapping():
 
 coordMapping = convert_coord_mapping()
 
-
-directPinScanner = (
-    """def __init__(self):
-    # create and register the scanner
-    self.matrix = KeysScanner(
-        # require argument:
-        pins=["""
-    + pins
-    + """],
-        # optional arguments with defaults:
-        value_when_pressed=False,
-        pull=True,
-        interval=0.02,  # Debounce time in floating point seconds
-        max_events=64
-    )"""
-)
-
 splitPinA = None
 splitPinB = None
 if config.get('splitPinA'):

--- a/src/main/saveConfig.ts
+++ b/src/main/saveConfig.ts
@@ -33,8 +33,8 @@ export const saveConfiguration = (data: string) => {
   }
 }
 
-const flashFileToKB = ({fileName, overwrite, fileContents }) => {
- if (!fs.existsSync(currentKeyboard.path + '/' + fileName) || overwrite) {
+const flashFileToKB = ({ fileName, overwrite, fileContents }) => {
+  if (!fs.existsSync(currentKeyboard.path + '/' + fileName) || overwrite) {
     fs.writeFile(currentKeyboard.path + '/' + fileName, fileContents, () => {
       console.log(fileName + 'File written successfully')
     })
@@ -119,7 +119,9 @@ import pog
 import customkeys
 
 keymap = [
-    ${pogConfig.keymap.map((layer) => '[' + layer.join(', ') + ']').join(', ')}
+    ${pogConfig.keymap
+      .map((layer) => '[' + layer.map((key) => (key ? key : 'KC.NO')).join(', ') + ']')
+      .join(', ')}
 ]
 
 encoderKeymap = []

--- a/src/main/saveConfig.ts
+++ b/src/main/saveConfig.ts
@@ -120,7 +120,7 @@ import customkeys
 
 keymap = [
     ${pogConfig.keymap
-      .map((layer) => '[' + layer.map((key) => (key ? key : 'KC.NO')).join(', ') + ']')
+      .map((layer) => '[' + layer.map((key) => (key ? key : 'KC.TRNS')).join(', ') + ']')
       .join(', ')}
 ]
 


### PR DESCRIPTION
Noticed a bit of errors setting up a directPins split keyboard.

Fix an issue with initialization of directPins scanner, where it would default to matrix scanner on coordmapHelper. 
Related issue - when coordMap was available the directPins scanner would not have "features" available.

Fix an issue with the keyMap being filled with "null" values if a layer had unmapped keys. Defaulting to KC.TRNS

Havent had the possibility to test if changes has any impact on matrix boards.