### PR TITLE
11 pog on boards without vbus sense

### DIFF
--- a/src/main/pythontemplates/pog.ts
+++ b/src/main/pythontemplates/pog.ts
@@ -20,7 +20,11 @@ except OSError as e:
 print("starting keyboard %s (%s)" % (config["name"], config["id"]))
 
 def pinValid(pin):
-    return pin in [f'board.{alias}' for alias in dir(board)]
+    if pin in [f'board.{alias}' for alias in dir(board)]:
+        return True
+    else:
+        print(f'INVALID PIN FOUND {pin}')
+        return False
 
 # Pin setup
 def renderPin(pin):
@@ -35,6 +39,7 @@ def renderPin(pin):
         pinLabel = pin
     if pinValid(pinLabel):
         return pinLabel
+    
 
 
 colPinsArray = []

--- a/src/main/pythontemplates/pog.ts
+++ b/src/main/pythontemplates/pog.ts
@@ -20,6 +20,10 @@ except OSError as e:
 print("starting keyboard %s (%s)" % (config["name"], config["id"]))
 
 def pinValid(pin):
+    if pin == "":
+        return False
+    if config["pinPrefix"] == "quickpin":
+        pin = f'{eval(pin)}'
     if pin in [f'board.{alias}' for alias in dir(board)]:
         return True
     else:

--- a/src/main/pythontemplates/pog.ts
+++ b/src/main/pythontemplates/pog.ts
@@ -1,7 +1,6 @@
 export const pogpy = `# pog.py Import the pog config - v0.9.5
 import json
 import board
-import microcontroller
 from kmk.keys import KC
 
 config = {}
@@ -41,8 +40,7 @@ def renderPin(pin):
 colPinsArray = []
 for i, item in enumerate(config["colPins"]):
     colPinsArray.append(renderPin(item))
-# Check validity of all the pins.
-# If a pin isn't valid it is omitted from the string
+# Remove the 'None's from the list of pins
 colPinsArray = [pin for pin in colPinsArray if pin is not None]
 colPins = ",".join(colPinsArray)
 if len(colPinsArray) == 1:
@@ -51,8 +49,7 @@ if len(colPinsArray) == 1:
 rowPinsArray = []
 for i, item in enumerate(config["rowPins"]):
     rowPinsArray.append(renderPin(item))
-# Check validity of all the pins.
-# If a pin isn't valid it is omitted from the string
+# Remove the 'None's from the list of pins
 rowPinsArray = [pin for pin in rowPinsArray if pin is not None]
 rowPins = ",".join(rowPinsArray)
 if len(rowPinsArray) == 1:
@@ -61,8 +58,7 @@ if len(rowPinsArray) == 1:
 pinsArray = []
 for i, item in enumerate(config["directPins"]):
     pinsArray.append(renderPin(item))
-# Check validity of all the pins.
-# If a pin isn't valid it is omitted from the string
+# Remove the 'None's from the list of pins
 pinsArray = [pin for pin in pinsArray if pin is not None]
 pins = ",".join(pinsArray)
 if len(pinsArray) == 1:


### PR DESCRIPTION
Added check for if the vbus pin is even needed and if it's a valid option. Added the pin checker to the `renderPin()` function. 
I've tested this with a rp2040-zero which doesn't have a VBUS_SENSE pin. I haven't tested the 'quickpin' version yet. 

I'm not a huge fan of this implementation overall because it allows incorrect setups to just quietly fail. If a user puts in improper pin numbers their firmware will run but they'll have a hard time figuring out why their keyboard isn't working. I've added a debug message when we find an invalid pin so if they connect to via serial they'll at least see that. It'll be less of an issue when we add the ability to check validity of pins before even creating the pog.json

Marked as draft as I want to test the quickpin before merging.

Fixes #11