### PR TITLE
Set correct side at one pin split

### DIFF
--- a/src/main/pythontemplates/kb.ts
+++ b/src/main/pythontemplates/kb.ts
@@ -76,7 +76,6 @@ class KMKKeyboard(_KMKKeyboard):
             else:
                 # Nested under pog.split == True => splitOnewire
                 print('split with 1 pin')
-                side = SplitSide.RIGHT if pog.splitSide == "right" else SplitSide.LEFT
                 self.split = Split(
                     split_side=side,
                     data_pin=pog.splitPinA,

--- a/src/main/pythontemplates/kb.ts
+++ b/src/main/pythontemplates/kb.ts
@@ -76,7 +76,9 @@ class KMKKeyboard(_KMKKeyboard):
             else:
                 # Nested under pog.split == True => splitOnewire
                 print('split with 1 pin')
+                side = SplitSide.RIGHT if pog.splitSide == "right" else SplitSide.LEFT
                 self.split = Split(
+                    split_side=side,
                     data_pin=pog.splitPinA,
                     use_pio=True)
 


### PR DESCRIPTION
Set the correct split side in kb.py when connecting over a single pin.